### PR TITLE
Added port mappings for Deluge

### DIFF
--- a/stacks/gnas-linuxserver-515/docker-compose.yml
+++ b/stacks/gnas-linuxserver-515/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       - TZ='America/Los Angeles'
     networks:
       - backend
+    ports:
+      - 8112:8112
+      - 58846:58846
+      - 58946:58946
+      - 58946:58946/udp
     volumes:
       - /opt/gnas/certs:/certs:ro
       - /opt/gnas/deluge:/config


### PR DESCRIPTION
## Purpose
Make sure we can actually reach Deluge

## Approach
Add ports to the stanza in the docker-compose file

### Open Questions and Pre-Merge TODOs
- All for trash TV?

### Development
- MOAR COFFEE

### References
Nope
