### PR TITLE
Add Jellyfin to GNAS

### DIFF
--- a/stacks/gnas-emr-lsio-remote/docker-compose.yml
+++ b/stacks/gnas-emr-lsio-remote/docker-compose.yml
@@ -62,6 +62,22 @@ services:
       - /opt/gnas/jackett:/config
       - /storage/Downloads/complete:/downloads
 
+  jellyfin:
+    container_name: jellyfin
+    image: linuxserver/jellyfin:latest
+    restart: unless-stopped
+    environment:
+      - PGID=65534
+      - PUID=65534
+      - TZ='America/Los Angeles'
+    ports": [
+      - 8096:8096/tcp
+      - 8920:8920/tcp
+    volumes:
+      - /opt/gnas/config:/config
+      - /storage:/data
+      - /storage/Transcode:/transcode
+
   lidarr:
     container_name: lidarr
     image: linuxserver/lidarr:latest

--- a/stacks/gnas-emr-lsio-remote/docker-compose.yml
+++ b/stacks/gnas-emr-lsio-remote/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - PGID=65534
       - PUID=65534
       - TZ='America/Los Angeles'
-    ports": [
+    ports:
       - 8096:8096/tcp
       - 8920:8920/tcp
     volumes:


### PR DESCRIPTION
Add Jellyfin to GNAS LSIO-EMR Portainer Template Stack

## Purpose
Add Jellyfin to the GNAS LSIO-EMR stack

## Approach
Add Jellyfin to the GNAS LSIO-EMR stack

### Open Questions and Pre-Merge TODOs
N/A

### Development
Add Jellyfin to the GNAS LSIO-EMR stack

### References
N/A